### PR TITLE
[MSVC] Fix narrowing conversion in trigs.cpp

### DIFF
--- a/Source/levels/trigs.cpp
+++ b/Source/levels/trigs.cpp
@@ -329,7 +329,7 @@ void InitLotusTriggers()
 				numtrigs++;
 			}
 			if (dPiece[i][j] == 51) {
-				trigs[numtrigs].position = { i + 1, j };
+				trigs[numtrigs].position = Point { i, j } + Displacement { 1, 0 };
 				trigs[numtrigs]._tmsg = WM_DIABNEXTLVL;
 				numtrigs++;
 			}


### PR DESCRIPTION
This fixes a build error in MSVC.

```
  [523/574] Building CXX object Source\CMakeFiles\libdevilutionx.dir\levels\trigs.cpp.obj
  FAILED: Source/CMakeFiles/libdevilutionx.dir/levels/trigs.cpp.obj 
  C:\PROGRA~1\MICROS~4\2022\COMMUN~1\VC\Tools\MSVC\1435~1.322\bin\Hostx86\x64\cl.exe  /nologo /TP -DASIO_STANDALONE -DBUILD_TESTING -DDEVILUTIONX_DEFAULT_RESAMPLER=Speex -DDEVILUTIONX_PALETTE_TRANSPARENCY_BLACK_16_LUT -DDEVILUTIONX_RESAMPLER_SDL -DDEVILUTIONX_RESAMPLER_SPEEX -DDISCORD -DFMT_SHARED -DPACKET_ENCRYPTION -D_CRT_SECURE_NO_WARNINGS -D_DEBUG -D_DVL_EXPORTING ... -std:c++20 /showIncludes /FoSource\CMakeFiles\libdevilutionx.dir\levels\trigs.cpp.obj /FdSource\CMakeFiles\libdevilutionx.dir\ /FS -c ...\Shadow-of-the-West\Source\levels\trigs.cpp
...\Shadow-of-the-West\Source\levels\trigs.cpp(332): error C2398: Element '1': conversion from 'int' to 'CoordT' requires a narrowing conversion
          with
          [
              CoordT=devilution::WorldTileCoord
          ]
```